### PR TITLE
Escape double quotes in docstrings

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ Changes in this project compared with the base project:
 - Keep nanosecond precision for `Timestamp`.
   - Subclass `datetime` to store the original nano-second value when converting from `Timestamp` to `datetime`.
   - On conversion from the subclass of `datetime` to `Timestamp` the original nano-second value is restored.
+- Minor fixes.
+  - Escaping double-quotes in docstrings.
 
 ## Installation
 

--- a/src/aristaproto/plugin/models.py
+++ b/src/aristaproto/plugin/models.py
@@ -154,7 +154,7 @@ def get_comment(
             if sci_loc.trailing_comments:
                 all_comments.append(sci_loc.trailing_comments)
 
-            lines = []
+            lines: list[str] = []
 
             for comment in all_comments:
                 lines += comment.split("\n")
@@ -171,6 +171,9 @@ def get_comment(
             # It is common for one line comments to start with a space, for example: // comment
             # We don't add this space to the generated file.
             lines = [line[1:] if line and line[0] == " " else line for line in lines]
+
+            # Escape any double-quotes to avoid interference with docstring quotes.
+            lines = [line.replace('"', '\\"') for line in lines]
 
             # This is a field, message, enum, service, or method
             if len(lines) == 1 and len(lines[0]) < 79 - indent - 6:


### PR DESCRIPTION
If a message field comment ends with a `"` it will produce `""""` (four) at the end of the docstring, which will not work. This PR escapes all double-quotes `"` to `\"` in all docstrings.