### PR TITLE
Fix test issues with newer protobuf versions

### DIFF
--- a/src/aristaproto/__init__.py
+++ b/src/aristaproto/__init__.py
@@ -42,7 +42,7 @@ from dateutil.parser import isoparse
 from typing_extensions import Self
 
 from ._types import T
-from ._version import __version__
+from ._version import __version__  # noqa: F401
 from .casing import (
     camel_case,
     safe_snake_case,

--- a/src/aristaproto/lib/google/protobuf/__init__.py
+++ b/src/aristaproto/lib/google/protobuf/__init__.py
@@ -1,1 +1,1 @@
-from aristaproto.lib.std.google.protobuf import *
+from aristaproto.lib.std.google.protobuf import *  # noqa: F403

--- a/src/aristaproto/lib/google/protobuf/compiler/__init__.py
+++ b/src/aristaproto/lib/google/protobuf/compiler/__init__.py
@@ -1,1 +1,1 @@
-from aristaproto.lib.std.google.protobuf.compiler import *
+from aristaproto.lib.std.google.protobuf.compiler import *  # noqa: F403

--- a/src/aristaproto/plugin/__init__.py
+++ b/src/aristaproto/plugin/__init__.py
@@ -1,1 +1,1 @@
-from .main import main
+from .main import main  # noqa: F401

--- a/src/aristaproto/plugin/module_validation.py
+++ b/src/aristaproto/plugin/module_validation.py
@@ -46,9 +46,13 @@ class ModuleValidator:
         full_line = line
         line = line.split("import", 1)[1]
         if "(" in line:
-            conditional = lambda line: ")" not in line
+
+            def conditional(line: str) -> bool:
+                return ")" not in line
         else:
-            conditional = lambda line: "\\" in line
+
+            def conditional(line: str) -> bool:
+                return "\\" in line
 
         # Remove open parenthesis if it exists.
         if "(" in line:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,14 @@
 import copy
+import os
 import sys
 
 import pytest
+
+
+# Change in aristaproto fork - moved from test_input.py to conftest.py.
+# Force pure-python implementation instead of C++, otherwise imports
+# break things because we can't properly reset the symbol database.
+os.environ["PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION"] = "python"
 
 
 def pytest_addoption(parser):

--- a/tests/inputs/googletypes_request/test_googletypes_request.py
+++ b/tests/inputs/googletypes_request/test_googletypes_request.py
@@ -44,4 +44,4 @@ async def test_channel_receives_wrapped_type(
 
     await service_method(service, wrapped_value)
 
-    assert channel.requests[0]["request"] == type(wrapped_value)
+    assert channel.requests[0]["request"] is type(wrapped_value)

--- a/tests/inputs/googletypes_response/test_googletypes_response.py
+++ b/tests/inputs/googletypes_response/test_googletypes_response.py
@@ -41,7 +41,7 @@ async def test_channel_receives_wrapped_type(
     await service_method(service, method_param)
 
     assert channel.requests[0]["response_type"] != Optional[type(value)]
-    assert channel.requests[0]["response_type"] == type(wrapped_value)
+    assert channel.requests[0]["response_type"] is type(wrapped_value)
 
 
 @pytest.mark.asyncio
@@ -61,4 +61,4 @@ async def test_service_unwraps_response(
     response_value = await service_method(service, method_param)
 
     assert response_value == value
-    assert type(response_value) == type(value)
+    assert type(response_value) is type(value)

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -59,15 +59,15 @@ def test_has_field():
 
     # Is always set from parse, even if all collections are empty
     with_collections_empty = WithCollections().parse(bytes(WithCollections()))
-    assert aristaproto.serialized_on_wire(with_collections_empty) == True
+    assert aristaproto.serialized_on_wire(with_collections_empty) is True
     with_collections_list = WithCollections().parse(
         bytes(WithCollections(test_list=["a", "b", "c"]))
     )
-    assert aristaproto.serialized_on_wire(with_collections_list) == True
+    assert aristaproto.serialized_on_wire(with_collections_list) is True
     with_collections_map = WithCollections().parse(
         bytes(WithCollections(test_map={"a": "b", "c": "d"}))
     )
-    assert aristaproto.serialized_on_wire(with_collections_map) == True
+    assert aristaproto.serialized_on_wire(with_collections_map) is True
 
 
 def test_class_init():

--- a/tests/test_inputs.py
+++ b/tests/test_inputs.py
@@ -13,6 +13,7 @@ from typing import (
 )
 
 import pytest
+from google.protobuf.json_format import Parse
 
 import aristaproto
 from tests.inputs import config as test_input_config
@@ -23,13 +24,6 @@ from tests.util import (
     get_test_case_json_data,
     inputs_path,
 )
-
-
-# Force pure-python implementation instead of C++, otherwise imports
-# break things because we can't properly reset the symbol database.
-os.environ["PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION"] = "python"
-
-from google.protobuf.json_format import Parse
 
 
 class TestCases:


### PR DESCRIPTION
In the tests that verify equivalence with the google implementation, some tests triggered the C++ implementation while others relied on the python implementation, but the library can only support one or the other per execution (caching of various objects).
By moving the selection of python implementation to conftest.py, we ensure the same method no matter which tests are included and their order.

Also fix various ruff issues.