### PR TITLE
Fix: Maintain nested indentation of comment lines

### DIFF
--- a/src/aristaproto/plugin/models.py
+++ b/src/aristaproto/plugin/models.py
@@ -31,6 +31,7 @@ reference to `A` to `B`'s `fields` attribute.
 
 import builtins
 import re
+import textwrap
 from dataclasses import (
     dataclass,
     field,
@@ -168,9 +169,10 @@ def get_comment(
             if lines and not lines[-1]:
                 lines.pop()  # Remove the last empty line
 
-            # It is common for one line comments to start with a space, for example: // comment
-            # We don't add this space to the generated file.
-            lines = [line.lstrip() for line in lines]
+            # SourceCodeInfo strips comment markers, but line comments commonly retain
+            # one shared leading space after `// `. Remove only common indentation so
+            # intentionally indented content inside descriptions is preserved.
+            lines = textwrap.dedent("\n".join(lines)).split("\n")
 
             # Escape any double-quotes to avoid interference with docstring quotes.
             lines = [line.replace('"', '\\"') for line in lines]

--- a/tests/inputs/regression_108/regression_108.proto
+++ b/tests/inputs/regression_108/regression_108.proto
@@ -1,0 +1,8 @@
+syntax = "proto3";
+
+package regression_108;
+
+// Summary:
+//   keeps one level of indentation
+//     keeps nested indentation too
+message Test {}

--- a/tests/inputs/regression_108/test_regression_108.py
+++ b/tests/inputs/regression_108/test_regression_108.py
@@ -1,0 +1,10 @@
+import inspect
+
+from tests.output_aristaproto.regression_108 import Test
+
+
+def test_multiline_comment_indentation_is_preserved():
+    assert (
+        inspect.getdoc(Test)
+        == "Summary:\n  keeps one level of indentation\n    keeps nested indentation too"
+    )


### PR DESCRIPTION
Avoid descriptions with nested indentation to be ltrimmed.