### PR TITLE
Feat: Preserve nanosecond precision for Timestamp

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@
 
 Changes in this project compared with the base project:
 
-- Renamed to `aristaproto`.
+- Renamed to `aristaproto`
+- Use a local `NanoDateTime` subclass of `datetime` to carry nanosecond precision through `Timestamp` conversions.
 
 Planned changes:
 
-- Support for precision timestamps (nanoseconds)
 - Support for grpcio async bindings (both client and server)
 
 ## Documentation

--- a/aristaproto/docs/getting-started.md
+++ b/aristaproto/docs/getting-started.md
@@ -225,6 +225,12 @@ Message objects include `aristaproto.Message.to_json` and
 `aristaproto.Message.to_dict`, `aristaproto.Message.from_dict` for
 converting back and forth from JSON serializable dicts.
 
+`google.protobuf.Timestamp` fields use timezone-aware `datetime.datetime`
+values. When binary or JSON data contains sub-microsecond precision,
+aristaproto preserves it by returning a `aristaproto.nano_datetime.NanoDatetime`,
+which is a `datetime.datetime` subclass. Timestamp JSON accepts and emits
+RFC 3339 strings with up to 9 fractional second digits.
+
 For compatibility the default is to convert field names to
 `aristaproto.Casing.CAMEL`. You can control this behavior by passing a
 different casing value, e.g:

--- a/aristaproto/docs/index.md
+++ b/aristaproto/docs/index.md
@@ -12,5 +12,6 @@ Python code, using modern language features.
 
 - Generated messages are both binary & JSON serializable
 - Messages use relevant python types, e.g. ``Enum``, ``datetime`` and ``timedelta`` objects
+- ``Timestamp`` values preserve nanosecond precision when binary or JSON data contains it
 - ``async``/``await`` support for gRPC Clients and Servers
 - Generates modern, readable, idiomatic python code

--- a/aristaproto/src/aristaproto/nano_datetime.py
+++ b/aristaproto/src/aristaproto/nano_datetime.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+import datetime
+import re
+from typing import Any
+
+import dateutil.parser
+from typing_extensions import Self
+
+_UTC = datetime.timezone.utc
+_TIMESTAMP_ZERO = datetime.datetime(1970, 1, 1, tzinfo=_UTC)
+_NANOS_PER_MICROSECOND = 1000
+_MICROS_PER_SECOND = 10**6
+_TIMESTAMP_RE = re.compile(
+    r"^"
+    r"(?P<date>\d{4}-\d{2}-\d{2})"
+    r"T"
+    r"(?P<time>\d{2}:\d{2}:\d{2})"
+    r"(?:\.(?P<fraction>\d{1,9}))?"
+    r"(?P<tz>Z|[+-]\d{2}:\d{2})"
+    r"$"
+)
+
+
+class NanoDatetime(datetime.datetime):
+    """A datetime that carries Timestamp sub-microsecond precision."""
+
+    __slots__ = ("_nanosecond_remainder",)
+
+    def __new__(
+        cls,
+        *args: Any,
+        nanosecond_remainder: int = 0,
+        **kwargs: Any,
+    ) -> Self:
+        if not 0 <= nanosecond_remainder < _NANOS_PER_MICROSECOND:
+            raise ValueError("nanosecond_remainder must be in range 0..999")
+
+        instance = super().__new__(cls, *args, **kwargs)
+        object.__setattr__(instance, "_nanosecond_remainder", nanosecond_remainder)
+        return instance
+
+    @property
+    def nanosecond_remainder(self) -> int:
+        return getattr(self, "_nanosecond_remainder", 0)
+
+    @property
+    def total_nanoseconds(self) -> int:
+        return self.microsecond * _NANOS_PER_MICROSECOND + self.nanosecond_remainder
+
+    def replace(self, *args: Any, nanosecond_remainder: int | None = None, **kwargs: Any) -> NanoDatetime:
+        if nanosecond_remainder is None:
+            nanosecond_remainder = self.nanosecond_remainder
+
+        replaced = super().replace(*args, **kwargs)
+        return _datetime_to_nano_datetime(replaced, nanosecond_remainder)
+
+    def __repr__(self) -> str:
+        base = super().__repr__()
+        return f"{base[:-1]}, nanosecond_remainder={self.nanosecond_remainder})"
+
+    def __eq__(self, other: Any) -> bool:
+        equal = super().__eq__(other)
+        if equal is NotImplemented or not isinstance(other, datetime.datetime):
+            return equal
+
+        return bool(equal) and self.nanosecond_remainder == _datetime_nanosecond_remainder(other)
+
+    def __ne__(self, other: Any) -> bool:
+        equal = self.__eq__(other)
+        if equal is NotImplemented:
+            return equal
+
+        return not equal
+
+    def __hash__(self) -> int:
+        if self.nanosecond_remainder == 0:
+            return super().__hash__()
+
+        return hash((super().__hash__(), self.nanosecond_remainder))
+
+    @staticmethod
+    def to_timestamp(dt: datetime.datetime) -> tuple[int, int]:
+        if not dt.tzinfo:
+            raise ValueError("datetime must be timezone aware")
+
+        nanos = _datetime_total_nanoseconds(dt)
+        dt = dt.astimezone(_UTC)
+
+        offset = dt - _TIMESTAMP_ZERO
+        offset_us = (offset.days * 24 * 60 * 60 + offset.seconds) * _MICROS_PER_SECOND + offset.microseconds
+        seconds, _ = divmod(offset_us, _MICROS_PER_SECOND)
+        return seconds, nanos
+
+    @staticmethod
+    def from_timestamp(seconds: int, nanos: int) -> NanoDatetime:
+        micros, nanosecond_remainder = divmod(nanos, _NANOS_PER_MICROSECOND)
+        offset = datetime.timedelta(seconds=seconds, microseconds=micros)
+        dt = _TIMESTAMP_ZERO + offset
+        return _datetime_to_nano_datetime(dt, nanosecond_remainder)
+
+    @staticmethod
+    def to_json(dt: datetime.datetime) -> str:
+        seconds, nanos = NanoDatetime.to_timestamp(dt)
+        dt = NanoDatetime.from_timestamp(seconds, nanos)
+        result = dt.replace(microsecond=0, nanosecond_remainder=0, tzinfo=None).isoformat()
+
+        if nanos == 0:
+            return f"{result}Z"
+        if nanos % 1_000_000 == 0:
+            return f"{result}.{nanos // 1_000_000:03d}Z"
+        if nanos % 1_000 == 0:
+            return f"{result}.{nanos // 1_000:06d}Z"
+
+        return f"{result}.{nanos:09d}Z"
+
+    @staticmethod
+    def from_rfc3339(value: str) -> datetime.datetime:
+        match = _TIMESTAMP_RE.match(value)
+        if match:
+            tz = "+00:00" if match.group("tz") == "Z" else match.group("tz")
+            dt = datetime.datetime.fromisoformat(f"{match.group('date')}T{match.group('time')}{tz}")
+
+            fraction = (match.group("fraction") or "").ljust(9, "0")
+            total_nanos = int(fraction) if fraction else 0
+            micros, nanosecond_remainder = divmod(total_nanos, _NANOS_PER_MICROSECOND)
+
+            dt = dt.replace(microsecond=micros).astimezone(_UTC)
+            return _datetime_to_nano_datetime(dt, nanosecond_remainder)
+
+        dt = dateutil.parser.isoparse(value)
+        return dt.astimezone(_UTC)
+
+
+def _datetime_nanosecond_remainder(dt: datetime.datetime) -> int:
+    if isinstance(dt, NanoDatetime):
+        return dt.nanosecond_remainder
+
+    return 0
+
+
+def _datetime_total_nanoseconds(dt: datetime.datetime) -> int:
+    if isinstance(dt, NanoDatetime):
+        return dt.total_nanoseconds
+
+    return dt.microsecond * _NANOS_PER_MICROSECOND
+
+
+def _datetime_to_nano_datetime(dt: datetime.datetime, nanosecond_remainder: int = 0) -> NanoDatetime:
+    return NanoDatetime(
+        dt.year,
+        dt.month,
+        dt.day,
+        dt.hour,
+        dt.minute,
+        dt.second,
+        dt.microsecond,
+        tzinfo=dt.tzinfo,
+        fold=dt.fold,
+        nanosecond_remainder=nanosecond_remainder,
+    )

--- a/aristaproto/tests/conformance/failing_tests.txt
+++ b/aristaproto/tests/conformance/failing_tests.txt
@@ -62,18 +62,6 @@ Required.Proto3.JsonInput.StringFieldNotAString # Should have failed to parse, b
 Required.Proto3.JsonInput.TimestampJsonInputLowercaseT # Should have failed to parse, but didn't.
 Required.Proto3.JsonInput.TimestampJsonInputLowercaseZ # Should have failed to parse, but didn't.
 Required.Proto3.JsonInput.TimestampJsonInputMissingT # Should have failed to parse, but didn't.
-Required.Proto3.JsonInput.TimestampLittleAfterEpochlValue.JsonOutput # Output was not equivalent to reference message: deleted: optional_timestamp.nanos: 1
-Required.Proto3.JsonInput.TimestampLittleAfterEpochlValue.ProtobufOutput # Output was not equivalent to reference message: deleted: optional_timestamp.nanos: 1
-Required.Proto3.JsonInput.TimestampLittleBeforeEpochValue.JsonOutput # Output was not equivalent to reference message: modified: optional_timestamp.nanos: 999999999 -> 999999000
-Required.Proto3.JsonInput.TimestampLittleBeforeEpochValue.ProtobufOutput # Output was not equivalent to reference message: modified: optional_timestamp.nanos: 999999999 -> 999999000
-Required.Proto3.JsonInput.TimestampMaxValue.JsonOutput # Output was not equivalent to reference message: modified: optional_timestamp.nanos: 999999999 -> 999999000
-Required.Proto3.JsonInput.TimestampMaxValue.ProtobufOutput # Output was not equivalent to reference message: modified: optional_timestamp.nanos: 999999999 -> 999999000
-Required.Proto3.JsonInput.TimestampNanoAfterEpochlValue.JsonOutput # Output was not equivalent to reference message: deleted: optional_timestamp.nanos: 1
-Required.Proto3.JsonInput.TimestampNanoAfterEpochlValue.ProtobufOutput # Output was not equivalent to reference message: deleted: optional_timestamp.nanos: 1
-Required.Proto3.JsonInput.TimestampNanoBeforeEpochValue.JsonOutput # Output was not equivalent to reference message: modified: optional_timestamp.nanos: 999999999 -> 999999000
-Required.Proto3.JsonInput.TimestampNanoBeforeEpochValue.ProtobufOutput # Output was not equivalent to reference message: modified: optional_timestamp.nanos: 999999999 -> 999999000
-Required.Proto3.JsonInput.TimestampRepeatedValue.JsonOutput # Output was not equivalent to reference message: modified: repeated_timestamp[1].nanos: 999999999 -> 999999000
-Required.Proto3.JsonInput.TimestampRepeatedValue.ProtobufOutput # Output was not equivalent to reference message: modified: repeated_timestamp[1].nanos: 999999999 -> 999999000
 Required.Proto3.JsonInput.TimestampWithMissingColonInOffset # Should have failed to parse, but didn't.
 Required.Proto3.JsonInput.Uint32FieldNotInteger # Should have failed to parse, but didn't.
 Required.Proto3.JsonInput.Uint32FieldTooLarge # Should have failed to parse, but didn't.

--- a/aristaproto/tests/test_nano_datetime.py
+++ b/aristaproto/tests/test_nano_datetime.py
@@ -1,0 +1,83 @@
+from datetime import datetime, timezone
+
+import pytest
+
+from aristaproto.nano_datetime import NanoDatetime
+
+
+@pytest.mark.parametrize("nanosecond_remainder", [-1, 1000])
+def test_nanosecond_remainder_must_be_sub_microsecond(nanosecond_remainder: int) -> None:
+    with pytest.raises(ValueError, match="nanosecond_remainder"):
+        NanoDatetime(2024, 1, 2, tzinfo=timezone.utc, nanosecond_remainder=nanosecond_remainder)
+
+
+def test_replace_preserves_nanosecond_remainder_by_default() -> None:
+    dt = NanoDatetime(2024, 1, 2, 3, 4, 5, 123456, tzinfo=timezone.utc, nanosecond_remainder=789)
+
+    replaced = dt.replace(second=6)
+
+    assert replaced == NanoDatetime(
+        2024,
+        1,
+        2,
+        3,
+        4,
+        6,
+        123456,
+        tzinfo=timezone.utc,
+        nanosecond_remainder=789,
+    )
+
+
+def test_replace_can_override_nanosecond_remainder() -> None:
+    dt = NanoDatetime(2024, 1, 2, 3, 4, 5, 123456, tzinfo=timezone.utc, nanosecond_remainder=789)
+
+    replaced = dt.replace(nanosecond_remainder=123)
+
+    assert replaced.nanosecond_remainder == 123
+    assert replaced.total_nanoseconds == 123456123
+
+
+def test_equality_and_hash_include_nanosecond_remainder() -> None:
+    base = datetime(2024, 1, 2, 3, 4, 5, 123456, tzinfo=timezone.utc)
+    zero_remainder = NanoDatetime(2024, 1, 2, 3, 4, 5, 123456, tzinfo=timezone.utc)
+    one_remainder = NanoDatetime(2024, 1, 2, 3, 4, 5, 123456, tzinfo=timezone.utc, nanosecond_remainder=1)
+    two_remainder = NanoDatetime(2024, 1, 2, 3, 4, 5, 123456, tzinfo=timezone.utc, nanosecond_remainder=2)
+
+    assert zero_remainder == base
+    assert hash(zero_remainder) == hash(base)
+    assert one_remainder != base
+    assert one_remainder != two_remainder
+    assert len({base, zero_remainder, one_remainder, two_remainder}) == 3
+
+
+@pytest.mark.parametrize(
+    ("dt", "expected"),
+    [
+        (NanoDatetime(1970, 1, 1, tzinfo=timezone.utc), "1970-01-01T00:00:00Z"),
+        (NanoDatetime(1970, 1, 1, 0, 0, 0, 123000, tzinfo=timezone.utc), "1970-01-01T00:00:00.123Z"),
+        (NanoDatetime(1970, 1, 1, 0, 0, 0, 123456, tzinfo=timezone.utc), "1970-01-01T00:00:00.123456Z"),
+        (
+            NanoDatetime(1970, 1, 1, 0, 0, 0, 123456, tzinfo=timezone.utc, nanosecond_remainder=789),
+            "1970-01-01T00:00:00.123456789Z",
+        ),
+    ],
+)
+def test_to_json_uses_required_fraction_widths(dt: NanoDatetime, expected: str) -> None:
+    assert NanoDatetime.to_json(dt) == expected
+
+
+@pytest.mark.parametrize(
+    ("value", "total_nanoseconds"),
+    [
+        ("1970-01-01T00:00:00.1Z", 100000000),
+        ("1970-01-01T00:00:00.1234Z", 123400000),
+        ("1970-01-01T00:00:00.12345678Z", 123456780),
+        ("1970-01-01T00:00:00.123456789Z", 123456789),
+    ],
+)
+def test_from_rfc3339_accepts_subsecond_fraction_widths(value: str, total_nanoseconds: int) -> None:
+    dt = NanoDatetime.from_rfc3339(value)
+
+    assert isinstance(dt, NanoDatetime)
+    assert dt.total_nanoseconds == total_nanoseconds

--- a/aristaproto/tests/test_timestamp.py
+++ b/aristaproto/tests/test_timestamp.py
@@ -5,6 +5,7 @@ from datetime import (
 
 import pytest
 
+from aristaproto.nano_datetime import NanoDatetime
 from tests.outputs.google.google.protobuf import Timestamp
 
 
@@ -34,3 +35,49 @@ def test_invalid_datetime():
     """
     with pytest.raises(ValueError):
         Timestamp.from_datetime(datetime.now())
+
+
+def test_timestamp_to_datetime_preserves_nanoseconds():
+    ts = Timestamp(seconds=1, nanos=123456789)
+
+    dt = ts.to_datetime()
+
+    assert isinstance(dt, NanoDatetime)
+    assert dt.microsecond == 123456
+    assert dt.nanosecond_remainder == 789
+    assert dt.total_nanoseconds == 123456789
+    assert Timestamp.from_datetime(dt) == ts
+
+
+def test_timestamp_to_datetime_preserves_negative_nanoseconds():
+    ts = Timestamp(seconds=-1, nanos=999999999)
+
+    dt = ts.to_datetime()
+
+    assert isinstance(dt, NanoDatetime)
+    assert dt == NanoDatetime(
+        1969,
+        12,
+        31,
+        23,
+        59,
+        59,
+        999999,
+        tzinfo=timezone.utc,
+        nanosecond_remainder=999,
+    )
+    assert Timestamp.from_datetime(dt) == ts
+
+
+def test_timestamp_dict_preserves_nanoseconds():
+    ts = Timestamp.from_dict("1970-01-01T00:00:01.123456789Z")
+
+    assert ts == Timestamp(seconds=1, nanos=123456789)
+    assert ts.to_dict() == "1970-01-01T00:00:01.123456789Z"
+
+
+def test_timestamp_dict_preserves_nanoseconds_with_offset():
+    ts = Timestamp.from_dict("1970-01-01T01:00:01.123456789+01:00")
+
+    assert ts == Timestamp(seconds=1, nanos=123456789)
+    assert ts.to_dict() == "1970-01-01T00:00:01.123456789Z"

--- a/aristaproto_compiler/src/aristaproto_compiler/known_types/__init__.py
+++ b/aristaproto_compiler/src/aristaproto_compiler/known_types/__init__.py
@@ -17,8 +17,7 @@ from .struct import ListValue, Struct, Value
 from .timestamp import Timestamp
 
 # For each (package, message name), lists the methods that should be added to the message definition.
-# The source code of the method is read from the `known_types` folder. If imports are needed, they can be directly added
-# to the template file: they will automatically be removed if not necessary.
+# The source code of the method is read from the `known_types` folder.
 KNOWN_METHODS: dict[tuple[str, str], list[Callable]] = {
     ("google.protobuf", "Any"): [Any.pack, Any.unpack, Any.to_dict, Any.from_dict],
     ("google.protobuf", "Timestamp"): [
@@ -105,6 +104,11 @@ KNOWN_METHODS: dict[tuple[str, str], list[Callable]] = {
         Value.from_dict,
         Value.to_dict,
     ],
+}
+
+# For each (package, message name), lists imports required by known-type methods.
+KNOWN_IMPORTS: dict[tuple[str, str], tuple[str, ...]] = {
+    ("google.protobuf", "Timestamp"): ("from aristaproto.nano_datetime import NanoDatetime",),
 }
 
 # A wrapped type is the type of a message that is automatically replaced by a known Python type.

--- a/aristaproto_compiler/src/aristaproto_compiler/known_types/timestamp.py
+++ b/aristaproto_compiler/src/aristaproto_compiler/known_types/timestamp.py
@@ -2,7 +2,7 @@ import datetime
 import typing
 
 import aristaproto
-import dateutil.parser
+from aristaproto.nano_datetime import NanoDatetime
 from typing_extensions import Self
 
 from aristaproto_compiler.lib.google.protobuf import Timestamp as VanillaTimestamp
@@ -11,56 +11,21 @@ from aristaproto_compiler.lib.google.protobuf import Timestamp as VanillaTimesta
 class Timestamp(VanillaTimestamp):
     @classmethod
     def from_datetime(cls, dt: datetime.datetime) -> Self:
-        if not dt.tzinfo:
-            raise ValueError("datetime must be timezone aware")
-
-        dt = dt.astimezone(datetime.timezone.utc)
-
-        # manual epoch offset calulation to avoid rounding errors,
-        # to support negative timestamps (before 1970) and skirt
-        # around datetime bugs (apparently 0 isn't a year in [0, 9999]??)
-        offset = dt - datetime.datetime(1970, 1, 1, tzinfo=datetime.timezone.utc)
-        # below is the same as timedelta.total_seconds() but without dividing by 1e6
-        # so we end up with microseconds as integers instead of seconds as float
-        offset_us = (offset.days * 24 * 60 * 60 + offset.seconds) * 10**6 + offset.microseconds
-        seconds, us = divmod(offset_us, 10**6)
-        return cls(seconds, us * 1000)
+        seconds, nanos = NanoDatetime.to_timestamp(dt)
+        return cls(seconds, nanos)
 
     def to_datetime(self) -> datetime.datetime:
-        # datetime.fromtimestamp() expects a timestamp in seconds, not microseconds
-        # if we pass it as a floating point number, we will run into rounding errors
-        # see also #407
-        offset = datetime.timedelta(seconds=self.seconds, microseconds=self.nanos // 1000)
-        return datetime.datetime(1970, 1, 1, tzinfo=datetime.timezone.utc) + offset
+        return NanoDatetime.from_timestamp(self.seconds, self.nanos)
 
     @staticmethod
     def timestamp_to_json(dt: datetime.datetime) -> str:
-        nanos = dt.microsecond * 1e3
-        if dt.tzinfo is not None:
-            # change timezone aware datetime objects to utc
-            dt = dt.astimezone(datetime.timezone.utc)
-        copy = dt.replace(microsecond=0, tzinfo=None)
-        result = copy.isoformat()
-        if (nanos % 1e9) == 0:
-            # If there are 0 fractional digits, the fractional
-            # point '.' should be omitted when serializing.
-            return f"{result}Z"
-        if (nanos % 1e6) == 0:
-            # Serialize 3 fractional digits.
-            return f"{result}.{int(nanos // 1e6):03d}Z"
-        if (nanos % 1e3) == 0:
-            # Serialize 6 fractional digits.
-            return f"{result}.{int(nanos // 1e3):06d}Z"
-        # Serialize 9 fractional digits.
-        return f"{result}.{nanos:09d}"
+        return NanoDatetime.to_json(dt)
 
     # TODO typing
     @classmethod
     def from_dict(cls, value, *, ignore_unknown_fields: bool = False) -> Self:
         if isinstance(value, str):
-            dt = dateutil.parser.isoparse(value)
-            dt = dt.astimezone(datetime.timezone.utc)
-            return cls.from_datetime(dt)
+            return cls.from_datetime(NanoDatetime.from_rfc3339(value))
 
         return super().from_dict(value, ignore_unknown_fields=ignore_unknown_fields)
 

--- a/aristaproto_compiler/src/aristaproto_compiler/lib/google/protobuf/__init__.py
+++ b/aristaproto_compiler/src/aristaproto_compiler/lib/google/protobuf/__init__.py
@@ -93,7 +93,7 @@ import warnings
 from dataclasses import dataclass
 
 import aristaproto
-import dateutil.parser
+from aristaproto.nano_datetime import NanoDatetime
 from typing_extensions import Self
 
 from ...message_pool import default_message_pool
@@ -3558,55 +3558,20 @@ class Timestamp(aristaproto.Message):
 
     @classmethod
     def from_datetime(cls, dt: datetime.datetime) -> Self:
-        if not dt.tzinfo:
-            raise ValueError("datetime must be timezone aware")
-
-        dt = dt.astimezone(datetime.timezone.utc)
-
-        # manual epoch offset calulation to avoid rounding errors,
-        # to support negative timestamps (before 1970) and skirt
-        # around datetime bugs (apparently 0 isn't a year in [0, 9999]??)
-        offset = dt - datetime.datetime(1970, 1, 1, tzinfo=datetime.timezone.utc)
-        # below is the same as timedelta.total_seconds() but without dividing by 1e6
-        # so we end up with microseconds as integers instead of seconds as float
-        offset_us = (offset.days * 24 * 60 * 60 + offset.seconds) * 10**6 + offset.microseconds
-        seconds, us = divmod(offset_us, 10**6)
-        return cls(seconds, us * 1000)
+        seconds, nanos = NanoDatetime.to_timestamp(dt)
+        return cls(seconds, nanos)
 
     def to_datetime(self) -> datetime.datetime:
-        # datetime.fromtimestamp() expects a timestamp in seconds, not microseconds
-        # if we pass it as a floating point number, we will run into rounding errors
-        # see also #407
-        offset = datetime.timedelta(seconds=self.seconds, microseconds=self.nanos // 1000)
-        return datetime.datetime(1970, 1, 1, tzinfo=datetime.timezone.utc) + offset
+        return NanoDatetime.from_timestamp(self.seconds, self.nanos)
 
     @staticmethod
     def timestamp_to_json(dt: datetime.datetime) -> str:
-        nanos = dt.microsecond * 1e3
-        if dt.tzinfo is not None:
-            # change timezone aware datetime objects to utc
-            dt = dt.astimezone(datetime.timezone.utc)
-        copy = dt.replace(microsecond=0, tzinfo=None)
-        result = copy.isoformat()
-        if (nanos % 1e9) == 0:
-            # If there are 0 fractional digits, the fractional
-            # point '.' should be omitted when serializing.
-            return f"{result}Z"
-        if (nanos % 1e6) == 0:
-            # Serialize 3 fractional digits.
-            return f"{result}.{int(nanos // 1e6):03d}Z"
-        if (nanos % 1e3) == 0:
-            # Serialize 6 fractional digits.
-            return f"{result}.{int(nanos // 1e3):06d}Z"
-        # Serialize 9 fractional digits.
-        return f"{result}.{nanos:09d}"
+        return NanoDatetime.to_json(dt)
 
     @classmethod
     def from_dict(cls, value, *, ignore_unknown_fields: bool = False) -> Self:
         if isinstance(value, str):
-            dt = dateutil.parser.isoparse(value)
-            dt = dt.astimezone(datetime.timezone.utc)
-            return cls.from_datetime(dt)
+            return cls.from_datetime(NanoDatetime.from_rfc3339(value))
 
         return super().from_dict(value, ignore_unknown_fields=ignore_unknown_fields)
 

--- a/aristaproto_compiler/src/aristaproto_compiler/plugin/models.py
+++ b/aristaproto_compiler/src/aristaproto_compiler/plugin/models.py
@@ -38,7 +38,7 @@ from aristaproto_compiler.compile.naming import (
     pythonize_field_name,
     pythonize_method_name,
 )
-from aristaproto_compiler.known_types import KNOWN_METHODS, WRAPPED_TYPES
+from aristaproto_compiler.known_types import KNOWN_IMPORTS, KNOWN_METHODS, WRAPPED_TYPES
 from aristaproto_compiler.lib.google.protobuf import (
     DescriptorProto,
     EnumDescriptorProto,
@@ -241,6 +241,15 @@ class OutputTemplate:
 
         return "\n".join(descriptors)
 
+    @property
+    def custom_imports(self) -> list[str]:
+        imports: set[str] = set()
+
+        for message in self.messages.values():
+            imports.update(message.custom_imports)
+
+        return sorted(imports)
+
 
 @dataclass(kw_only=True)
 class MessageCompiler(ProtoContentBase):
@@ -291,6 +300,13 @@ class MessageCompiler(ProtoContentBase):
             methods_source.append(source.strip())
 
         return methods_source
+
+    @property
+    def custom_imports(self) -> tuple[str, ...]:
+        """
+        Return imports required by custom known-type methods.
+        """
+        return KNOWN_IMPORTS.get((self.source_file.package, self.py_name), ())
 
     @property
     def descriptor_name(self) -> str:

--- a/aristaproto_compiler/src/aristaproto_compiler/templates/header.py.j2
+++ b/aristaproto_compiler/src/aristaproto_compiler/templates/header.py.j2
@@ -14,7 +14,6 @@ __all__ = (
 import re
 import builtins
 import datetime
-import dateutil.parser
 import warnings
 from collections.abc import AsyncIterable, AsyncIterator, Iterable, Iterator
 import typing
@@ -34,6 +33,9 @@ from aristaproto import grpclib as aristaproto_grpclib
 import grpc
 import grpclib
 from google.protobuf.descriptor import Descriptor, EnumDescriptor
+{% for custom_import in output_file.custom_imports %}
+{{ custom_import }}
+{% endfor %}
 
 {# Import the message pool of the generated code. #}
 {% if output_file.package %}

--- a/aristaproto_compiler/tests/test_known_type_imports.py
+++ b/aristaproto_compiler/tests/test_known_type_imports.py
@@ -1,0 +1,81 @@
+from collections.abc import Iterable
+from pathlib import Path
+
+from aristaproto_compiler.lib.google.protobuf import (
+    DescriptorProto,
+    FieldDescriptorProto,
+    FieldDescriptorProtoLabel,
+    FieldDescriptorProtoType,
+    FileDescriptorProto,
+    SourceCodeInfo,
+)
+from aristaproto_compiler.lib.google.protobuf.compiler import CodeGeneratorRequest
+from aristaproto_compiler.plugin.parser import generate_code
+
+
+def compile_message(package: str, message_name: str, fields: Iterable[FieldDescriptorProto]) -> str:
+    source_file = FileDescriptorProto(
+        name=f"{message_name.lower()}.proto",
+        package=package,
+        syntax="proto3",
+        source_code_info=SourceCodeInfo(),
+        message_type=[
+            DescriptorProto(
+                name=message_name,
+                field=list(fields),
+            ),
+        ],
+    )
+    response = generate_code(
+        CodeGeneratorRequest(
+            file_to_generate=[source_file.name],
+            proto_file=[source_file],
+        )
+    )
+
+    output_file_name = Path(*package.split("."), "__init__.py")
+    generated_files = {Path(file.name): file.content for file in response.file}
+
+    return generated_files[output_file_name]
+
+
+def test_timestamp_output_imports_nano_datetime() -> None:
+    generated = compile_message(
+        "google.protobuf",
+        "Timestamp",
+        [
+            FieldDescriptorProto(
+                name="seconds",
+                number=1,
+                label=FieldDescriptorProtoLabel.OPTIONAL,
+                type=FieldDescriptorProtoType.INT64,
+            ),
+            FieldDescriptorProto(
+                name="nanos",
+                number=2,
+                label=FieldDescriptorProtoLabel.OPTIONAL,
+                type=FieldDescriptorProtoType.INT32,
+            ),
+        ],
+    )
+
+    assert "from aristaproto.nano_datetime import NanoDatetime" in generated
+    assert "NanoDatetime.from_timestamp" in generated
+    assert "dateutil.parser" not in generated
+
+
+def test_non_timestamp_output_does_not_import_nano_datetime() -> None:
+    generated = compile_message(
+        "import_fixture",
+        "NonTimestamp",
+        [
+            FieldDescriptorProto(
+                name="value",
+                number=1,
+                label=FieldDescriptorProtoLabel.OPTIONAL,
+                type=FieldDescriptorProtoType.BOOL,
+            )
+        ],
+    )
+
+    assert "aristaproto.nano_datetime" not in generated


### PR DESCRIPTION
Add NanoDatetime to carry sub-microsecond precision through Timestamp conversions and JSON parsing/formatting while keeping generated field types as datetime.datetime.

Generate the NanoDatetime import only for known types that need it, and add runtime/compiler coverage for the new behavior.